### PR TITLE
feat: Implement template-based config generation

### DIFF
--- a/src/PulsePanel.Api/Models/Models.cs
+++ b/src/PulsePanel.Api/Models/Models.cs
@@ -20,8 +20,8 @@ public record GameDefinition(
 );
 
 public record TemplateSpec(
-    string Source,   // relative to registry templates folder or embedded later
-    string Target    // relative path under server config dir
+    string Target,
+    string Content
 );
 
 public class ServerEntry {

--- a/src/PulsePanel.Api/Program.cs
+++ b/src/PulsePanel.Api/Program.cs
@@ -230,6 +230,36 @@ app.MapPut("/api/servers/{id}/config", async (string id, ServerStore store, Http
     return Results.Json(new { ok = true });
 });
 
+app.MapPost("/api/servers/{id}/config/generate", async (string id, ServerStore store, ServerRegistry reg, ServerProcessService procs) =>
+{
+    var list = store.Load();
+    var s = list.FirstOrDefault(x => x.Id == id);
+    if (s is null) return Results.NotFound();
+
+    var def = reg.Get(s.Game);
+    if (def is null) return Results.BadRequest(new { error = "unknown game id" });
+
+    var configDir = procs.ConfigDir(id);
+    procs.EnsureLayout(id);
+
+    if (def.Templates is not null)
+    {
+        foreach (var template in def.Templates)
+        {
+            var content = ReplaceTokens(template.Content, s.Tokens);
+            var targetPath = Path.Combine(configDir, template.Target);
+            await File.WriteAllTextAsync(targetPath, content);
+
+            if (targetPath.EndsWith(".sh") && !OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(targetPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+        }
+    }
+
+    return Results.Json(new { ok = true });
+});
+
 app.MapDelete("/api/servers/{id}", (string id, ServerStore store, ServerProcessService procs) =>
 {
     var list = store.Load();

--- a/src/PulsePanel.Api/server_registry.json
+++ b/src/PulsePanel.Api/server_registry.json
@@ -23,7 +23,12 @@
       },
       "defaultPorts": { "2456/udp": 2456, "2457/udp": 2457, "2458/udp": 2458 },
       "tokens": { "hostname": "Pulse Valheim", "world": "Dedicated", "password": "changeme", "port": 2456 },
-      "templates": []
+      "templates": [
+        {
+          "Target": "start.sh",
+          "Content": "#!/bin/bash\nexport TEMP=/tmp\n./valheim_server.x86_64 -name \"{{hostname}}\" -port {{port}} -world \"{{world}}\" -password \"{{password}}\" -public 1"
+        }
+      ]
     },
     {
       "id": "generic-steam",

--- a/src/PulsePanel.Api/wwwroot/app.js
+++ b/src/PulsePanel.Api/wwwroot/app.js
@@ -22,6 +22,7 @@ async function refresh() {
       </div>
       <div class="row">
         <button data-act="install">Install/Update</button>
+        <button data-act="config">Generate Config</button>
         <button data-act="start">${s.status === "running" ? "Restart" : "Start"}</button>
         <button data-act="stop">Stop</button>
         <button data-act="logs">Logs</button>
@@ -33,6 +34,11 @@ async function refresh() {
     card.querySelector('[data-act="install"]').onclick = async ()=>{
       await api(`/api/servers/${s.id}/install`, { method: "POST" });
       await refresh();
+    };
+    card.querySelector('[data-act="config"]').onclick = async ()=>{
+      const res = await api(`/api/servers/${s.id}/config/generate`, { method: "POST" });
+      if (res.ok) alert("Config generated successfully!");
+      else alert("Failed to generate config.");
     };
     card.querySelector('[data-act="start"]').onclick = async ()=>{
       if (s.status === "running") {


### PR DESCRIPTION
This commit introduces a new feature that allows for the generation of server configuration files from templates defined in `server_registry.json`.

- The `GameDefinition` model has been updated to support inline templates.
- A new API endpoint `POST /api/servers/{id}/config/generate` has been added to trigger the config generation for a server.
- The frontend has been updated with a "Generate Config" button on the server card to call this new endpoint.
- A sample template has been added for the Valheim game definition.