### PR TITLE
feat: Make SteamCMD path configurable

### DIFF
--- a/src/PulsePanel.Api/Services/SteamCmdService.cs
+++ b/src/PulsePanel.Api/Services/SteamCmdService.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.IO.Compression;
 using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
 
 namespace PulsePanel.Api.Services;
 
@@ -8,10 +9,12 @@ public class SteamCmdService {
     private readonly string _toolsDir;
     private readonly ILogger<SteamCmdService> _logger;
 
-    public SteamCmdService(IWebHostEnvironment env, ILogger<SteamCmdService> logger) {
-        _toolsDir = Path.GetFullPath(Path.Combine(env.ContentRootPath, "..", "..", "tools", "steamcmd"));
-        Directory.CreateDirectory(_toolsDir);
+    public SteamCmdService(IWebHostEnvironment env, ILogger<SteamCmdService> logger, IConfiguration config) {
         _logger = logger;
+        var steamCmdRelativePath = config.GetValue<string>("PulsePanel:SteamCmdPath") ?? "steamcmd";
+        var rootDir = Path.GetFullPath(Path.Combine(env.ContentRootPath, "..", ".."));
+        _toolsDir = Path.Combine(rootDir, steamCmdRelativePath);
+        Directory.CreateDirectory(_toolsDir);
     }
 
     public string SteamCmdPath {

--- a/src/PulsePanel.Api/appsettings.json
+++ b/src/PulsePanel.Api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "PulsePanel": {
+    "SteamCmdPath": "steamcmd"
+  }
 }


### PR DESCRIPTION
This commit refactors the `SteamCmdService` to use a configurable path for the SteamCMD installation, instead of a hardcoded one.

- A new setting `PulsePanel:SteamCmdPath` has been added to `appsettings.json`.
- `SteamCmdService` now reads this configuration value to determine the location of the SteamCMD directory.
- The existing logic for auto-downloading and managing SteamCMD is preserved.